### PR TITLE
Add support for Terratec Cinergy S2 USB HD Rev.2

### DIFF
--- a/drivers/media/dvb/dvb-usb/dw2102.c
+++ b/drivers/media/dvb/dvb-usb/dw2102.c
@@ -1182,6 +1182,13 @@ static int su3000_frontend_attach(struct dvb_usb_adapter *d)
 		err("command 0x0e transfer failed.");
 
 	obuf[0] = 0xe;
+	obuf[1] = 0x02;
+	obuf[2] = 1;
+
+	if (dvb_usb_generic_rw(d->dev, obuf, 3, ibuf, 1, 0) < 0)
+		err("command 0x0e transfer failed.");
+
+	obuf[0] = 0xe;
 	obuf[1] = 0x83;
 	obuf[2] = 0;
 
@@ -1447,6 +1454,7 @@ enum dw2102_table_entry {
 	TEVII_S480_1,
 	TEVII_S480_2,
 	X3M_SPC1400HD,
+	TERRATEC_CINERGY_S2_R2,
 };
 
 static struct usb_device_id dw2102_table[] = {
@@ -1465,6 +1473,7 @@ static struct usb_device_id dw2102_table[] = {
 	[TEVII_S480_1] = {USB_DEVICE(0x9022, USB_PID_TEVII_S480_1)},
 	[TEVII_S480_2] = {USB_DEVICE(0x9022, USB_PID_TEVII_S480_2)},
 	[X3M_SPC1400HD] = {USB_DEVICE(0x1f4d, 0x3100)},
+	[TERRATEC_CINERGY_S2_R2] = {USB_DEVICE(USB_VID_TERRATEC, 0x00b0)},
 	{ }
 };
 
@@ -1853,7 +1862,7 @@ static struct dvb_usb_device_properties su3000_properties = {
 		}},
 		}
 	},
-	.num_device_descs = 3,
+	.num_device_descs = 4,
 	.devices = {
 		{ "SU3000HD DVB-S USB2.0",
 			{ &dw2102_table[GENIATECH_SU3000], NULL },
@@ -1865,6 +1874,10 @@ static struct dvb_usb_device_properties su3000_properties = {
 		},
 		{ "X3M TV SPC1400HD PCI",
 			{ &dw2102_table[X3M_SPC1400HD], NULL },
+			{ NULL },
+		},
+		{ "Terratec Cinergy S2 USB HD Rev.2",
+			{ &dw2102_table[TERRATEC_CINERGY_S2_R2], NULL },
 			{ NULL },
 		},
 	}


### PR DESCRIPTION
Provide Terratec Cinergy S2 USB HD Rev.2 support.

A newer version of this patch is already included in mainline (torvalds/linux@44122dd6b6b872d6f1ec151f89942f66b715222c).
This is an older patch suitable for v3.6.
